### PR TITLE
[READY] - Updating vm-bhyve to v1.5.0 release

### DIFF
--- a/sysutils/vm-bhyve/Makefile
+++ b/sysutils/vm-bhyve/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	vm-bhyve
-PORTVERSION=	1.5.0.p1
+PORTVERSION=	1.5.0
 CATEGORIES=	sysutils
 
 MAINTAINER=	churchers@gmail.com
@@ -12,7 +12,7 @@ RUN_DEPENDS=	${LOCALBASE}/share/certs/ca-root-nss.crt:security/ca_root_nss
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	churchers
-GH_TAGNAME=     5c8674939ebb75dc8a0e7e4b4c34d877a1c51faf
+GH_TAGNAME=     v1.5.0
 
 NO_ARCH=	yes
 NO_BUILD=	yes

--- a/sysutils/vm-bhyve/distinfo
+++ b/sysutils/vm-bhyve/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1581480299
-SHA256 (churchers-vm-bhyve-1.5.0.p1-5c8674939ebb75dc8a0e7e4b4c34d877a1c51faf_GH0.tar.gz) = dd3e68ef01accc75a10e4c8cdf10200182d4e0fac2fb3b085ea939e0aa696e51
-SIZE (churchers-vm-bhyve-1.5.0.p1-5c8674939ebb75dc8a0e7e4b4c34d877a1c51faf_GH0.tar.gz) = 74021
+TIMESTAMP = 1658623253
+SHA256 (churchers-vm-bhyve-1.5.0-v1.5.0_GH0.tar.gz) = a69a01d4051fff8865619f5b7ff3609308b8da493c330b26faf429690f40ee19
+SIZE (churchers-vm-bhyve-1.5.0-v1.5.0_GH0.tar.gz) = 76273


### PR DESCRIPTION
## Description

Release for vm-bhyve 1.5.0 has not made it to the ports tree as of 07/26/2022. Updating it hear to consume for scale 19x

## Testing
- installed on FreeBSD 13.1